### PR TITLE
Add sudo check to installer script

### DIFF
--- a/mayanode_script.sh
+++ b/mayanode_script.sh
@@ -10,6 +10,11 @@ if [[ $EUID -eq 0 ]]; then
   exit 1
 fi
 
+if ! sudo -n true 2>/dev/null; then
+  echo "✗ This installer requires passwordless sudo access."
+  exit 1
+fi
+
 set -Eeuo pipefail  # Fail fast on errors, undefined vars, or pipeline errors.
 
 # ─────────────────────── Pretty-Printing Helpers ──────────────────────────


### PR DESCRIPTION
## Summary
- fail early when passwordless sudo is not available

## Testing
- `bash -n mayanode_script.sh`

------
https://chatgpt.com/codex/tasks/task_e_68692d7d2ef08327a53922407ad43974